### PR TITLE
Fix KQL operators, add search caching and read_list_items

### DIFF
--- a/src/sharepoint_rest_api/builders/rest_builder.py
+++ b/src/sharepoint_rest_api/builders/rest_builder.py
@@ -32,25 +32,32 @@ class RestBuilder:
             "not": "<>",
             "contains": ":",
             "eq": ":",
-            "gte": ">=..",
-            "gt": ">..",
-            "lte": "..<=",
-            "lt": "..<",
-            "between": "..",
+            "gte": ">=",
+            "gt": ">",
+            "lte": "<=",
+            "lt": "<",
+            "between": ":",
         }
         kql_op = kql_op_map.get(operator_key, ":")
         values = [v.strip() for v in filter_value.split(",")]
 
         if operator_key == "not_in":
-            return [f'-"{v}"' for v in values]
-        if operator_key == "contains":
-            return [f'{raw_name}:"{values[0]}*"']
-        if kql_op == "<>":
-            return [f'{raw_name}<>"{values[0]}"']
-        if len(values) == 1:
-            return [f'{raw_name}:"{values[0]}"']
-        or_parts = [f'"{v}"' for v in values]
-        return [f"{raw_name}:({' OR '.join(or_parts)})"]
+            result = [f'-"{v}"' for v in values]
+        elif operator_key == "contains":
+            result = [f'{raw_name}:"{values[0]}*"']
+        elif kql_op == "<>":
+            result = [f'{raw_name}<>"{values[0]}"']
+        elif operator_key in ("gte", "gt", "lte", "lt"):
+            result = [f"{raw_name}{kql_op}{values[0]}"]
+        elif operator_key == "between":
+            range_parts = filter_value.split("__")
+            result = [f"{raw_name}:{range_parts[0]}..{range_parts[-1]}"]
+        elif len(values) == 1:
+            result = [f'{raw_name}:"{values[0]}"']
+        else:
+            or_parts = [f'"{v}"' for v in values]
+            result = [f"{raw_name}:({' OR '.join(or_parts)})"]
+        return result
 
     @staticmethod
     def build_kql(search=None, filters=None):

--- a/src/sharepoint_rest_api/graph_client.py
+++ b/src/sharepoint_rest_api/graph_client.py
@@ -1,4 +1,7 @@
+import hashlib
+import json
 import logging
+import time
 from urllib.parse import quote
 
 import requests
@@ -12,6 +15,26 @@ from sharepoint_rest_api.builders.rest_builder import (
 )
 
 logger = logging.getLogger(__name__)
+
+_scan_cache = {}
+
+
+def _get_scan_cache(key):
+    entry = _scan_cache.get(key)
+    if entry is not None and time.time() < entry["expires"]:
+        return entry["value"]
+    if entry is not None:
+        del _scan_cache[key]
+    return None
+
+
+def _set_scan_cache(key, value, ttl=300):
+    _scan_cache[key] = {"value": value, "expires": time.time() + ttl}
+    if len(_scan_cache) > 500:
+        now = time.time()
+        stale = [k for k, v in _scan_cache.items() if now >= v["expires"]]
+        for k in stale:
+            del _scan_cache[k]
 
 
 class GraphClientError(Exception):
@@ -343,40 +366,58 @@ class GraphClient:
         return items, total_rows
 
     def _execute_paginated_search(self, kql, page, page_size, post_filters, reverse_map):
+        if not post_filters:
+            start_row = (page - 1) * page_size
+            items, total_rows = self._execute_search_page(kql, start_row, page_size, reverse_map=reverse_map)
+            logger.info(f"Graph Search API: {total_rows} total, returned {len(items)} for page {page}")
+            return items, total_rows
+
+        # Cache scan results in-process so every page sees the same pool
+        # regardless of Django's cache backend.
+        scan_key = hashlib.md5(
+            json.dumps(
+                {
+                    "kql": kql,
+                    "post_filters": dict(sorted(post_filters.items())),
+                    "page_size": page_size,
+                },
+                sort_keys=True,
+            ).encode(),
+            usedforsecurity=False,
+        ).hexdigest()
+
+        all_items = _get_scan_cache(scan_key)
+        if all_items is None:
+            all_items = self._scan_all_post_filtered(kql, page_size, post_filters, reverse_map)
+            _set_scan_cache(scan_key, all_items)
+
+        total_rows = len(all_items)
+        offset = (page - 1) * page_size
+        items = all_items[offset : offset + page_size]
+
+        logger.info(f"Graph Search API: {total_rows} total, returned {len(items)} for page {page}")
+        return items, total_rows
+
+    def _scan_all_post_filtered(self, kql, page_size, post_filters, reverse_map):
+        """Scan ahead and return ALL post-filtered items (no page slicing)."""
         all_items = []
-        total_rows = 0
-        max_scanned = 5 if post_filters else 1
-        pages_scanned = 0
+        max_scanned = 5
 
         for scan_offset in range(max_scanned):
-            pages_scanned = scan_offset + 1
-            start_row = (page - 1 + scan_offset) * page_size
+            start_row = scan_offset * page_size
             page_items, page_total = self._execute_search_page(kql, start_row, page_size, reverse_map=reverse_map)
-            if scan_offset == 0:
-                total_rows = page_total
 
-            if post_filters:
-                page_items = [
-                    it for it in page_items if self._matches_post_filters(it, post_filters, reverse_map=reverse_map)
-                ]
-
+            page_items = [
+                it for it in page_items if self._matches_post_filters(it, post_filters, reverse_map=reverse_map)
+            ]
             all_items.extend(page_items)
 
-            if len(all_items) >= page_size:
-                break
             if page_total == 0:
                 break
-            if not post_filters and len(page_items) < page_size:
-                break
-            if total_rows > 0 and start_row + page_size >= total_rows:
+            if start_row + page_size >= page_total:
                 break
 
-        items = all_items[:page_size]
-        if post_filters:
-            total_rows = len(all_items)
-
-        logger.info(f"Graph Search API: {total_rows} total, returned {len(items)} (scanned {pages_scanned} pages)")
-        return items, total_rows
+        return all_items
 
     def search(
         self,
@@ -384,7 +425,6 @@ class GraphClient:
         filters=None,
         page=1,
         searchable_properties=None,
-        reverse_map=None,
         **kwargs,
     ):
         """Search SharePoint content using the Microsoft Graph Search API.
@@ -403,12 +443,16 @@ class GraphClient:
                      searchable via KQL. Properties NOT in this set are
                      excluded from KQL and applied as post-filters after batch
                      enrichment. If None, all properties are treated as post-filters.
-            reverse_map: Dict mapping managed property names -> serializer
-                     field names (e.g. {'DonorCode': 'DRPDonorCode'}) for
-                     enrichment reverse-mapping.
             **kwargs: Extra keyword arguments for API compatibility.
+                      Accepted kwargs:
+                      - reverse_map: Dict mapping managed property names ->
+                        serializer field names for enrichment reverse-mapping.
+                      - page_size: Number of items per page. Defaults to
+                        config.GRAPH_PAGE_SIZE.
 
         """
+        reverse_map = kwargs.pop("reverse_map", None)
+        page_size = kwargs.pop("page_size", None) or config.GRAPH_PAGE_SIZE
         searchable_filters = {}
         post_filters = {}
         if filters:
@@ -420,4 +464,25 @@ class GraphClient:
                     post_filters[name] = value
 
         kql = RestBuilder.build_kql(search=search, filters=searchable_filters)
-        return self._execute_paginated_search(kql, page, config.GRAPH_PAGE_SIZE, post_filters, reverse_map)
+        return self._execute_paginated_search(kql, page, page_size, post_filters, reverse_map)
+
+    def read_list_items(self, list_name):
+        """Read all items from a SharePoint list via Graph API.
+
+        Uses pagination to fetch all items from the specified list.
+        Returns a list of item dicts (including expanded field values).
+
+        Args:
+            list_name: Display name of the SharePoint list.
+
+        """
+        items = []
+        site_path = quote(self.site_id, safe="")
+        list_path = quote(list_name, safe="")
+        url = f"{GRAPH_URL}/sites/{site_path}/lists/{list_path}/items?expand=fields&$top=500"
+        while url:
+            response = self.get(url)
+            data = response.json()
+            items.extend(data.get("value", []))
+            url = data.get("@odata.nextLink")
+        return items

--- a/src/sharepoint_rest_api/graph_client.py
+++ b/src/sharepoint_rest_api/graph_client.py
@@ -386,12 +386,14 @@ class GraphClient:
             usedforsecurity=False,
         ).hexdigest()
 
-        all_items = _get_scan_cache(scan_key)
-        if all_items is None:
-            all_items = self._scan_all_post_filtered(kql, page_size, post_filters, reverse_map)
-            _set_scan_cache(scan_key, all_items)
+        cached = _get_scan_cache(scan_key)
+        if cached is not None:
+            all_items, scan_total = cached
+        else:
+            all_items, scan_total = self._scan_all_post_filtered(kql, page_size, post_filters, reverse_map)
+            _set_scan_cache(scan_key, (all_items, scan_total))
 
-        total_rows = len(all_items)
+        total_rows = scan_total
         offset = (page - 1) * page_size
         items = all_items[offset : offset + page_size]
 
@@ -399,13 +401,17 @@ class GraphClient:
         return items, total_rows
 
     def _scan_all_post_filtered(self, kql, page_size, post_filters, reverse_map):
-        """Scan ahead and return ALL post-filtered items (no page slicing)."""
+        """Scan ahead and return (all_filtered_items, raw_total)."""
         all_items = []
+        raw_total = 0
         max_scanned = 5
 
         for scan_offset in range(max_scanned):
             start_row = scan_offset * page_size
             page_items, page_total = self._execute_search_page(kql, start_row, page_size, reverse_map=reverse_map)
+
+            if scan_offset == 0:
+                raw_total = page_total
 
             page_items = [
                 it for it in page_items if self._matches_post_filters(it, post_filters, reverse_map=reverse_map)
@@ -417,7 +423,7 @@ class GraphClient:
             if start_row + page_size >= page_total:
                 break
 
-        return all_items
+        return all_items, raw_total
 
     def search(
         self,

--- a/src/sharepoint_rest_api/graph_client.py
+++ b/src/sharepoint_rest_api/graph_client.py
@@ -386,14 +386,12 @@ class GraphClient:
             usedforsecurity=False,
         ).hexdigest()
 
-        cached = _get_scan_cache(scan_key)
-        if cached is not None:
-            all_items, scan_total = cached
-        else:
-            all_items, scan_total = self._scan_all_post_filtered(kql, page_size, post_filters, reverse_map)
-            _set_scan_cache(scan_key, (all_items, scan_total))
+        all_items = _get_scan_cache(scan_key)
+        if all_items is None:
+            all_items = self._scan_all_post_filtered(kql, page_size, post_filters, reverse_map)
+            _set_scan_cache(scan_key, all_items)
 
-        total_rows = scan_total
+        total_rows = len(all_items)
         offset = (page - 1) * page_size
         items = all_items[offset : offset + page_size]
 
@@ -401,17 +399,13 @@ class GraphClient:
         return items, total_rows
 
     def _scan_all_post_filtered(self, kql, page_size, post_filters, reverse_map):
-        """Scan ahead and return (all_filtered_items, raw_total)."""
+        """Scan ahead and return ALL post-filtered items (no page slicing)."""
         all_items = []
-        raw_total = 0
         max_scanned = 5
 
         for scan_offset in range(max_scanned):
             start_row = scan_offset * page_size
             page_items, page_total = self._execute_search_page(kql, start_row, page_size, reverse_map=reverse_map)
-
-            if scan_offset == 0:
-                raw_total = page_total
 
             page_items = [
                 it for it in page_items if self._matches_post_filters(it, post_filters, reverse_map=reverse_map)
@@ -423,7 +417,7 @@ class GraphClient:
             if start_row + page_size >= page_total:
                 break
 
-        return all_items, raw_total
+        return all_items
 
     def search(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,13 @@ from rest_framework.test import APIClient
 
 import pytest
 
+from sharepoint_rest_api.graph_client import _scan_cache
 from tests.factories import UserFactory
+
+
+@pytest.fixture(autouse=True)
+def _clear_scan_cache():
+    _scan_cache.clear()
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,12 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from sharepoint_rest_api.graph_client import _scan_cache
-from tests.factories import UserFactory
+# Must be set before any import that triggers config.py (e.g. graph_client),
+# because SHAREPOINT_CONNECTION is evaluated at module load time.
+os.environ.setdefault("SHAREPOINT_CONNECTION", "user")
+
+from sharepoint_rest_api.graph_client import _scan_cache  # noqa: E402
+from tests.factories import UserFactory  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -26,7 +30,6 @@ def _mock_sharepoint_auth():
 def pytest_configure(config):
     # enable this to remove deprecations
     os.environ["CELERY_TASK_ALWAYS_EAGER"] = "1"
-    os.environ["SHAREPOINT_CONNECTION"] = "user"
     os.environ["STATIC_ROOT"] = tempfile.gettempdir()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from unittest import mock
 
 from rest_framework.test import APIClient
 
@@ -12,6 +13,14 @@ from tests.factories import UserFactory
 @pytest.fixture(autouse=True)
 def _clear_scan_cache():
     _scan_cache.clear()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _mock_sharepoint_auth():
+    patcher = mock.patch("office365.runtime.auth.authentication_context.AuthenticationContext.authenticate_request")
+    patcher.start()
+    yield
+    patcher.stop()
 
 
 def pytest_configure(config):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,11 +39,10 @@ def sh_client(library, request, db):
 
 @pytest.fixture(scope="session", autouse=True)
 def mock_client():
-    patcher = mock.patch("office365.runtime.auth.authentication_context.AuthenticationContext")
-    my_mock = patcher.start()
-    my_mock.acquire_token.return_value = True
+    patcher = mock.patch("office365.runtime.auth.authentication_context.AuthenticationContext.authenticate_request")
+    patcher.start()
     yield
-    patcher.stop()  # not needed just for clarity
+    patcher.stop()
 
 
 @VCR.use_cassette(str(Path(__file__).parent / "vcr_cassettes/client/folders.yml"))

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -15,6 +15,7 @@ from sharepoint_rest_api.serializers.sharepoint import (
     SharePointSettingsSerializer,
     SharePointUrlSerializer,
 )
+from sharepoint_rest_api.graph_client import _get_scan_cache, _set_scan_cache
 from sharepoint_rest_api.utils import first_upper, get_cache_key
 
 
@@ -158,3 +159,24 @@ def test_kql_exclusion_filter():
 def test_get_cache_key_with_args():
     key = get_cache_key(("foo", "bar"), key1="val1")
     assert isinstance(key, int)
+
+
+# ---- graph_client.py _get_scan_cache coverage ----
+
+
+def test_scan_cache_hit():
+    _set_scan_cache("test_key", "cached_value")
+    assert _get_scan_cache("test_key") == "cached_value"
+
+
+def test_scan_cache_expired():
+    _set_scan_cache("expired_key", "stale", ttl=-1)
+    assert _get_scan_cache("expired_key") is None
+
+
+def test_scan_cache_eviction():
+    for i in range(500):
+        _set_scan_cache(f"stale_{i}", "stale", ttl=-1)
+    _set_scan_cache("fresh", "val", ttl=300)
+    assert _get_scan_cache("stale_0") is None
+    assert _get_scan_cache("fresh") == "val"

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -1302,7 +1302,7 @@ def test_search_with_post_filters(mock_cca, mock_post):
         filters={"ReportStatus": "Final"},
         searchable_properties=set(),
     )
-    assert total == 3
+    assert total == 2
     assert len(items) == 2
 
 
@@ -1366,7 +1366,7 @@ def test_search_with_post_filters_single_page(mock_cca, mock_post):
             filters={"ReportStatus": "Final"},
             searchable_properties=set(),
         )
-    assert total == 3
+    assert total == 1
     assert len(items) == 1
     assert items[0]["DocId"] == "doc1"
 
@@ -1449,7 +1449,7 @@ def test_search_post_filters_no_match(mock_cca, mock_post):
             filters={"ReportStatus": "Final"},
             searchable_properties=set(),
         )
-    assert total == 2
+    assert total == 0
     assert len(items) == 0
 
 

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -4,12 +4,7 @@ import pytest
 import requests
 
 from sharepoint_rest_api.builders.rest_builder import RestBuilder
-from sharepoint_rest_api.graph_client import GraphClient, GraphClientError, GRAPH_URL, _scan_cache
-
-
-@pytest.fixture(autouse=True)
-def _clear_scan_cache():
-    _scan_cache.clear()
+from sharepoint_rest_api.graph_client import GraphClient, GraphClientError, GRAPH_URL
 
 
 # ---- __init__ ----------------------------------------------------------------

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -4,7 +4,12 @@ import pytest
 import requests
 
 from sharepoint_rest_api.builders.rest_builder import RestBuilder
-from sharepoint_rest_api.graph_client import GraphClient, GraphClientError, GRAPH_URL
+from sharepoint_rest_api.graph_client import GraphClient, GraphClientError, GRAPH_URL, _scan_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_scan_cache():
+    _scan_cache.clear()
 
 
 # ---- __init__ ----------------------------------------------------------------

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -284,9 +284,9 @@ def test_kql_multiple_filters():
     assert " AND " in result
 
 
-def test_kql_gte_falls_back_to_eq():
+def test_kql_gte():
     result = RestBuilder.build_kql(filters={"Size__gte": "1000"})
-    assert result == 'Size:"1000"'
+    assert result == "Size>=1000"
 
 
 # ---- _matches_post_filters ---------------------------------------------------
@@ -1302,92 +1302,73 @@ def test_search_with_post_filters(mock_cca, mock_post):
         filters={"ReportStatus": "Final"},
         searchable_properties=set(),
     )
-    assert total == 2
+    assert total == 3
     assert len(items) == 2
 
 
 @mock.patch("sharepoint_rest_api.graph_client.requests.post")
 @mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
-def test_search_with_post_filters_scans_pages(mock_cca, mock_post):
+def test_search_with_post_filters_single_page(mock_cca, mock_post):
     mock_app = mock_cca.return_value
     mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
 
-    responses = [
-        {
-            "value": [
-                {
-                    "hitsContainers": [
-                        {
-                            "total": 2,
-                            "hits": [
-                                {
-                                    "hitId": "hit1",
-                                    "rank": 1,
-                                    "resource": {
-                                        "id": "doc1",
-                                        "name": "doc1.pdf",
-                                        "webUrl": "https://sharepoint.com/site/doc1",
-                                        "size": 512,
-                                        "lastModifiedDateTime": "2024-01-01T00:00:00Z",
-                                        "listItem": {"fields": {"ReportStatus": "Final"}},
-                                        "parentReference": {
-                                            "siteId": "s1",
-                                            "sharepointIds": {"listId": "l1", "listItemId": "i1"},
-                                        },
+    mock_resp = mock.MagicMock()
+    mock_resp.json.return_value = {
+        "value": [
+            {
+                "hitsContainers": [
+                    {
+                        "total": 3,
+                        "hits": [
+                            {
+                                "hitId": "hit1",
+                                "rank": 1,
+                                "resource": {
+                                    "id": "doc1",
+                                    "name": "doc1.pdf",
+                                    "webUrl": "https://sharepoint.com/site/doc1",
+                                    "size": 512,
+                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                    "listItem": {"fields": {"ReportStatus": "Final"}},
+                                    "parentReference": {
+                                        "siteId": "s1",
+                                        "sharepointIds": {"listId": "l1", "listItemId": "i1"},
                                     },
-                                }
-                            ],
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "value": [
-                {
-                    "hitsContainers": [
-                        {
-                            "total": 2,
-                            "hits": [
-                                {
-                                    "hitId": "hit_extra",
-                                    "rank": 1,
-                                    "resource": {
-                                        "id": "doc_extra",
-                                        "name": "doc_extra.pdf",
-                                        "webUrl": "https://sharepoint.com/site/doc_extra",
-                                        "size": 512,
-                                        "lastModifiedDateTime": "2024-01-01T00:00:00Z",
-                                        "listItem": {"fields": {"ReportStatus": "Final"}},
-                                        "parentReference": {
-                                            "siteId": "s1",
-                                            "sharepointIds": {"listId": "l1", "listItemId": "i_extra"},
-                                        },
+                                },
+                            },
+                            {
+                                "hitId": "hit2",
+                                "rank": 2,
+                                "resource": {
+                                    "id": "doc2",
+                                    "name": "doc2.pdf",
+                                    "webUrl": "https://sharepoint.com/site/doc2",
+                                    "size": 512,
+                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                    "listItem": {"fields": {"ReportStatus": "Draft"}},
+                                    "parentReference": {
+                                        "siteId": "s1",
+                                        "sharepointIds": {"listId": "l1", "listItemId": "i2"},
                                     },
-                                }
-                            ],
-                        }
-                    ]
-                }
-            ]
-        },
-    ]
-
-    mock_resp1 = mock.MagicMock()
-    mock_resp1.json.return_value = responses[0]
-    mock_resp2 = mock.MagicMock()
-    mock_resp2.json.return_value = responses[1]
-    mock_post.side_effect = [mock_resp1, mock_resp2]
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    mock_post.return_value = mock_resp
 
     client = GraphClient()
     with mock.patch.object(GraphClient, "_fetch_item_fields"):
-        with mock.patch("sharepoint_rest_api.graph_client.config.GRAPH_PAGE_SIZE", 1):
-            items, total = client.search(
-                page=1,
-                filters={"ReportStatus": "Final"},
-                searchable_properties=set(),
-            )
+        items, total = client.search(
+            filters={"ReportStatus": "Final"},
+            searchable_properties=set(),
+        )
+    assert total == 3
     assert len(items) == 1
+    assert items[0]["DocId"] == "doc1"
 
 
 @mock.patch("sharepoint_rest_api.graph_client.requests.post")
@@ -1430,54 +1411,7 @@ def test_search_with_pagination(mock_cca, mock_post):
 
 @mock.patch("sharepoint_rest_api.graph_client.requests.post")
 @mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
-def test_search_stops_when_enough_items(mock_cca, mock_post):
-    mock_app = mock_cca.return_value
-    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
-
-    def side_effect(*args, **kwargs):
-        mock_resp = mock.MagicMock()
-        mock_resp.json.return_value = {
-            "value": [
-                {
-                    "hitsContainers": [
-                        {
-                            "total": 50,
-                            "hits": [
-                                {
-                                    "hitId": "hit",
-                                    "rank": 1,
-                                    "resource": {
-                                        "id": "doc",
-                                        "name": "doc.pdf",
-                                        "webUrl": "https://sharepoint.com/site/doc",
-                                        "size": 512,
-                                        "lastModifiedDateTime": "2024-01-01T00:00:00Z",
-                                        "listItem": {"fields": {"ReportStatus": "Final"}},
-                                    },
-                                }
-                                for _ in range(10)
-                            ],
-                        }
-                    ]
-                }
-            ]
-        }
-        return mock_resp
-
-    mock_post.side_effect = side_effect
-
-    client = GraphClient()
-    with mock.patch.object(GraphClient, "_fetch_item_fields"):
-        items, total = client.search(
-            filters={"ReportStatus": "Final"},
-            searchable_properties=set(),
-        )
-    assert len(items) > 0
-
-
-@mock.patch("sharepoint_rest_api.graph_client.requests.post")
-@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
-def test_search_loop_exhausts_with_post_filters(mock_cca, mock_post):
+def test_search_post_filters_no_match(mock_cca, mock_post):
     mock_app = mock_cca.return_value
     mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
 
@@ -1487,7 +1421,51 @@ def test_search_loop_exhausts_with_post_filters(mock_cca, mock_post):
             {
                 "hitsContainers": [
                     {
-                        "total": 50,
+                        "total": 2,
+                        "hits": [
+                            {
+                                "hitId": "hit1",
+                                "rank": 1,
+                                "resource": {
+                                    "id": "doc1",
+                                    "name": "doc1.pdf",
+                                    "webUrl": "https://sharepoint.com/site/doc1",
+                                    "size": 512,
+                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                    "listItem": {"fields": {"ReportStatus": "Draft"}},
+                                },
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    mock_post.return_value = mock_resp
+
+    client = GraphClient()
+    with mock.patch.object(GraphClient, "_fetch_item_fields"):
+        items, total = client.search(
+            filters={"ReportStatus": "Final"},
+            searchable_properties=set(),
+        )
+    assert total == 2
+    assert len(items) == 0
+
+
+@mock.patch("sharepoint_rest_api.graph_client.requests.post")
+@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
+def test_search_with_custom_page_size(mock_cca, mock_post):
+    mock_app = mock_cca.return_value
+    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
+
+    mock_resp = mock.MagicMock()
+    mock_resp.json.return_value = {
+        "value": [
+            {
+                "hitsContainers": [
+                    {
+                        "total": 2,
                         "hits": [
                             {
                                 "hitId": f"hit{i}",
@@ -1498,7 +1476,6 @@ def test_search_loop_exhausts_with_post_filters(mock_cca, mock_post):
                                     "webUrl": f"https://sharepoint.com/site/doc{i}",
                                     "size": 512,
                                     "lastModifiedDateTime": "2024-01-01T00:00:00Z",
-                                    "listItem": {"fields": {"ReportStatus": "Final"}},
                                 },
                             }
                             for i in range(2)
@@ -1511,18 +1488,16 @@ def test_search_loop_exhausts_with_post_filters(mock_cca, mock_post):
     mock_post.return_value = mock_resp
 
     client = GraphClient()
-    with mock.patch.object(GraphClient, "_fetch_item_fields"):
-        with mock.patch("sharepoint_rest_api.graph_client.config.GRAPH_PAGE_SIZE", 3):
-            items, total = client.search(
-                filters={"ReportStatus": "Final"},
-                searchable_properties=set(),
-            )
-    assert len(items) == 3
+    items, total = client.search(page_size=10)
+    assert total == 2
+    assert len(items) == 2
+    body = mock_post.call_args[1]["json"]
+    assert body["requests"][0]["size"] == 10
 
 
 @mock.patch("sharepoint_rest_api.graph_client.requests.post")
 @mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
-def test_search_loop_exhausts_all_pages(mock_cca, mock_post):
+def test_search_default_page_size(mock_cca, mock_post):
     mock_app = mock_cca.return_value
     mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
 
@@ -1532,22 +1507,8 @@ def test_search_loop_exhausts_all_pages(mock_cca, mock_post):
             {
                 "hitsContainers": [
                     {
-                        "total": 200,
-                        "hits": [
-                            {
-                                "hitId": f"hit{i}",
-                                "rank": i,
-                                "resource": {
-                                    "id": f"doc{i}",
-                                    "name": f"doc{i}.pdf",
-                                    "webUrl": f"https://sharepoint.com/site/doc{i}",
-                                    "size": 512,
-                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
-                                    "listItem": {"fields": {"ReportStatus": "Final"}},
-                                },
-                            }
-                            for i in range(1)
-                        ],
+                        "total": 0,
+                        "hits": [],
                     }
                 ]
             }
@@ -1556,13 +1517,10 @@ def test_search_loop_exhausts_all_pages(mock_cca, mock_post):
     mock_post.return_value = mock_resp
 
     client = GraphClient()
-    with mock.patch.object(GraphClient, "_fetch_item_fields"):
-        with mock.patch("sharepoint_rest_api.graph_client.config.GRAPH_PAGE_SIZE", 25):
-            items, total = client.search(
-                filters={"ReportStatus": "Final"},
-                searchable_properties=set(),
-            )
-    assert len(items) == 5
+    with mock.patch("sharepoint_rest_api.graph_client.config.GRAPH_PAGE_SIZE", 20):
+        client.search()
+    body = mock_post.call_args[1]["json"]
+    assert body["requests"][0]["size"] == 20
 
 
 @mock.patch("sharepoint_rest_api.graph_client.requests.post")

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -1542,3 +1542,225 @@ def test_search_with_all_params(mock_cca, mock_post):
     )
     assert total == 0
     assert items == []
+
+
+@mock.patch("sharepoint_rest_api.graph_client.requests.get")
+@mock.patch("sharepoint_rest_api.graph_client.requests.post")
+@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
+def test_read_list_items(mock_cca, mock_post, mock_get):
+    mock_app = mock_cca.return_value
+    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
+
+    page1_resp = mock.MagicMock()
+    page1_resp.json.return_value = {
+        "value": [{"id": "1", "fields": {"Title": "Doc1"}}, {"id": "2", "fields": {"Title": "Doc2"}}],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/sites/site123/lists/MyList/items?$skiptoken=abc",
+    }
+    page2_resp = mock.MagicMock()
+    page2_resp.json.return_value = {
+        "value": [{"id": "3", "fields": {"Title": "Doc3"}}],
+    }
+    mock_get.side_effect = [page1_resp, page2_resp]
+
+    client = GraphClient()
+    with mock.patch.object(GraphClient, "_get_site_id", return_value="site123"):
+        items = client.read_list_items("MyList")
+
+    assert len(items) == 3
+    assert items[0]["fields"]["Title"] == "Doc1"
+    assert items[2]["fields"]["Title"] == "Doc3"
+    assert mock_get.call_count == 2
+
+
+@mock.patch("sharepoint_rest_api.graph_client.requests.post")
+@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
+def test_search_post_filter_cache_hit(mock_cca, mock_post):
+    mock_app = mock_cca.return_value
+    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
+    mock_resp = mock.MagicMock()
+    mock_resp.json.return_value = {
+        "value": [
+            {
+                "hitsContainers": [
+                    {
+                        "total": 1,
+                        "hits": [
+                            {
+                                "hitId": "hit1",
+                                "rank": 1,
+                                "resource": {
+                                    "id": "doc1",
+                                    "name": "doc1.pdf",
+                                    "webUrl": "https://sharepoint.com/site/doc1",
+                                    "size": 512,
+                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                    "listItem": {"fields": {"ReportStatus": "Final"}},
+                                    "parentReference": {
+                                        "siteId": "s1",
+                                        "sharepointIds": {"listId": "l1", "listItemId": "i1"},
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    mock_post.return_value = mock_resp
+
+    client = GraphClient()
+    with mock.patch.object(GraphClient, "_fetch_item_fields"):
+        items1, total1 = client.search(filters={"ReportStatus": "Final"}, searchable_properties=set())
+        items2, total2 = client.search(filters={"ReportStatus": "Final"}, searchable_properties=set())
+
+    assert total1 == total2 == 1
+    assert len(items1) == len(items2) == 1
+    assert mock_post.call_count == 1
+
+
+@mock.patch("sharepoint_rest_api.graph_client.requests.post")
+@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
+def test_scan_all_post_filtered_multi_page(mock_cca, mock_post):
+    mock_app = mock_cca.return_value
+    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
+
+    page1_resp = mock.MagicMock()
+    page1_resp.json.return_value = {
+        "value": [
+            {
+                "hitsContainers": [
+                    {
+                        "total": 10,
+                        "hits": [
+                            {
+                                "hitId": f"hit{i}",
+                                "rank": i,
+                                "resource": {
+                                    "id": f"doc{i}",
+                                    "name": f"doc{i}.pdf",
+                                    "webUrl": f"https://sharepoint.com/site/doc{i}",
+                                    "size": 512,
+                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                    "listItem": {"fields": {"ReportStatus": "Final"}},
+                                    "parentReference": {
+                                        "siteId": "s1",
+                                        "sharepointIds": {"listId": "l1", "listItemId": f"i{i}"},
+                                    },
+                                },
+                            }
+                            for i in range(2)
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    page2_resp = mock.MagicMock()
+    page2_resp.json.return_value = {
+        "value": [
+            {
+                "hitsContainers": [
+                    {
+                        "total": 10,
+                        "hits": [
+                            {
+                                "hitId": "hit_extra",
+                                "rank": 1,
+                                "resource": {
+                                    "id": "doc_extra",
+                                    "name": "doc_extra.pdf",
+                                    "webUrl": "https://sharepoint.com/site/doc_extra",
+                                    "size": 512,
+                                    "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                    "listItem": {"fields": {"ReportStatus": "Final"}},
+                                    "parentReference": {
+                                        "siteId": "s1",
+                                        "sharepointIds": {"listId": "l1", "listItemId": "i_extra"},
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    mock_post.side_effect = [page1_resp, page2_resp]
+
+    client = GraphClient()
+    with mock.patch.object(GraphClient, "_fetch_item_fields"):
+        with mock.patch("sharepoint_rest_api.graph_client.config.GRAPH_PAGE_SIZE", 5):
+            items, total = client.search(filters={"ReportStatus": "Final"}, searchable_properties=set())
+
+    assert total == 3
+    assert len(items) == 3
+    assert mock_post.call_count == 2
+
+
+@mock.patch("sharepoint_rest_api.graph_client.requests.post")
+@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
+def test_scan_all_post_filtered_empty_total(mock_cca, mock_post):
+    mock_app = mock_cca.return_value
+    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
+    mock_resp = mock.MagicMock()
+    mock_resp.json.return_value = {"value": [{"hitsContainers": [{"total": 0, "hits": []}]}]}
+    mock_post.return_value = mock_resp
+
+    client = GraphClient()
+    items, total = client.search(filters={"ReportStatus": "Final"}, searchable_properties=set())
+
+    assert total == 0
+    assert items == []
+
+
+@mock.patch("sharepoint_rest_api.graph_client.requests.post")
+@mock.patch("sharepoint_rest_api.graph_client.ConfidentialClientApplication")
+def test_scan_all_post_filtered_exhaust_all_pages(mock_cca, mock_post):
+    mock_app = mock_cca.return_value
+    mock_app.acquire_token_for_client.return_value = {"access_token": "t"}
+
+    def side_effect(*args, **kwargs):
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {
+            "value": [
+                {
+                    "hitsContainers": [
+                        {
+                            "total": 50,
+                            "hits": [
+                                {
+                                    "hitId": "hit",
+                                    "rank": 1,
+                                    "resource": {
+                                        "id": "doc",
+                                        "name": "doc.pdf",
+                                        "webUrl": "https://sharepoint.com/site/doc",
+                                        "size": 512,
+                                        "lastModifiedDateTime": "2024-01-01T00:00:00Z",
+                                        "listItem": {"fields": {"ReportStatus": "Final"}},
+                                        "parentReference": {
+                                            "siteId": "s1",
+                                            "sharepointIds": {"listId": "l1", "listItemId": "i1"},
+                                        },
+                                    },
+                                }
+                                for _ in range(2)
+                            ],
+                        }
+                    ]
+                }
+            ]
+        }
+        return mock_resp
+
+    mock_post.side_effect = side_effect
+
+    client = GraphClient()
+    with mock.patch.object(GraphClient, "_fetch_item_fields"):
+        with mock.patch("sharepoint_rest_api.graph_client.config.GRAPH_PAGE_SIZE", 3):
+            items, total = client.search(filters={"ReportStatus": "Final"}, searchable_properties=set())
+
+    assert total == 10
+    assert len(items) == 3
+    assert mock_post.call_count == 5

--- a/tests/test_rest_builder.py
+++ b/tests/test_rest_builder.py
@@ -47,6 +47,31 @@ def test_kql_clause_unknown_operator():
     assert result == ['Donor:"val"']
 
 
+def test_kql_clause_gte():
+    result = RestBuilder.build_kql_clause("Size__gte", "1000")
+    assert result == ["Size>=1000"]
+
+
+def test_kql_clause_gt():
+    result = RestBuilder.build_kql_clause("Size__gt", "1000")
+    assert result == ["Size>1000"]
+
+
+def test_kql_clause_lte():
+    result = RestBuilder.build_kql_clause("Size__lte", "1000")
+    assert result == ["Size<=1000"]
+
+
+def test_kql_clause_lt():
+    result = RestBuilder.build_kql_clause("Size__lt", "1000")
+    assert result == ["Size<1000"]
+
+
+def test_kql_clause_between():
+    result = RestBuilder.build_kql_clause("Size__between", "1000__5000")
+    assert result == ["Size:1000..5000"]
+
+
 # ---- build_kql ---------------------------------------------------------------
 
 
@@ -100,9 +125,29 @@ def test_kql_multiple_filters():
     assert " AND " in result
 
 
-def test_kql_gte_falls_back_to_eq():
+def test_kql_gte():
     result = RestBuilder.build_kql(filters={"Size__gte": "1000"})
-    assert result == 'Size:"1000"'
+    assert result == "Size>=1000"
+
+
+def test_kql_gt():
+    result = RestBuilder.build_kql(filters={"Size__gt": "1000"})
+    assert result == "Size>1000"
+
+
+def test_kql_lte():
+    result = RestBuilder.build_kql(filters={"Size__lte": "1000"})
+    assert result == "Size<=1000"
+
+
+def test_kql_lt():
+    result = RestBuilder.build_kql(filters={"Size__lt": "1000"})
+    assert result == "Size<1000"
+
+
+def test_kql_between():
+    result = RestBuilder.build_kql(filters={"Size__between": "1000__5000"})
+    assert result == "Size:1000..5000"
 
 
 # ---- build_search_request_body -----------------------------------------------


### PR DESCRIPTION
### Changes

**KQL operator fixes** (`rest_builder.py`):
- `gte`, `gt`, `lte`, `lt` now emit proper KQL syntax (e.g. `Size>=1000`) instead of falling back to `eq`
- `between` now emits `Field:1000..5000` syntax
- Refactored `build_kql_clause` to use a single return path (fixes PLR0911)

**Graph search improvements** (`graph_client.py`):
- Added in-memory scan caching for post-filtered search results so every paginated request sees the same result pool
- Refactored `_execute_paginated_search` to scan up to 5 pages when post-filters are present, then cache all matching items
- Added `page_size` parameter to `search()` method (passed via kwargs)
- Added `read_list_items(list_name)` convenience method to fetch all items from a SharePoint list via paginated Graph API calls
- Fixed Python 2-style exception syntax

**Test updates**:
- Updated tests to match new KQL operator behavior
- Simplified post-filter and pagination tests to reflect the new scanning/caching logic
- Added tests for new `page_size` parameter and default page size behavior