### PR TITLE
fix: use Refinable managed property names in KQL, fix AND separator

### DIFF
--- a/src/sharepoint_rest_api/builders/rest_builder.py
+++ b/src/sharepoint_rest_api/builders/rest_builder.py
@@ -46,7 +46,7 @@ class RestBuilder:
         elif operator_key == "contains":
             result = [f'{raw_name}:"{values[0]}*"']
         elif kql_op == "<>":
-            result = [f'{raw_name}<>"{values[0]}"']
+            result = [f'-{raw_name}:"{values[0]}"']
         elif operator_key in ("gte", "gt", "lte", "lt"):
             result = [f"{raw_name}{kql_op}{values[0]}"]
         elif operator_key == "between":
@@ -76,8 +76,8 @@ class RestBuilder:
         if not clauses:
             return search or "*"
         if search:
-            return f"{search} AND {' AND '.join(clauses)}"
-        return " AND ".join(clauses)
+            return f"{search} {' '.join(clauses)}"
+        return " ".join(clauses)
 
     @staticmethod
     def build_search_request_body(kql, start_row, page_size):

--- a/src/sharepoint_rest_api/builders/rest_builder.py
+++ b/src/sharepoint_rest_api/builders/rest_builder.py
@@ -80,8 +80,18 @@ class RestBuilder:
         return " ".join(clauses)
 
     @staticmethod
-    def build_search_request_body(kql, start_row, page_size):
-        """Build the JSON POST body for a Graph Search API request."""
+    def build_search_request_body(kql, start_row, page_size, fields=None):
+        """Build the JSON POST body for a Graph Search API request.
+
+        Args:
+            kql: KQL query string.
+            start_row: Zero-based row offset.
+            page_size: Number of results to fetch.
+            fields: Optional list of managed property names to include
+                    in search results for each hit. If omitted, only
+                    default resource properties are returned.
+
+        """
         request_body = {
             "entityTypes": ["driveItem"],
             "query": {"queryString": kql},
@@ -89,6 +99,8 @@ class RestBuilder:
             "from": start_row,
             "size": page_size,
         }
+        if fields:
+            request_body["fields"] = fields
         return {"requests": [request_body]}
 
     @staticmethod

--- a/src/sharepoint_rest_api/graph_client.py
+++ b/src/sharepoint_rest_api/graph_client.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import logging
 import time
+from datetime import datetime
 from urllib.parse import quote
 
 import requests
@@ -17,6 +18,16 @@ from sharepoint_rest_api.builders.rest_builder import (
 logger = logging.getLogger(__name__)
 
 _scan_cache = {}
+
+
+def _parse_last_modified(item, field="LastModifiedTime"):
+    val = item.get(field) or ""
+    if not val:
+        return datetime.min
+    try:
+        return datetime.fromisoformat(val)
+    except ValueError, TypeError:
+        return datetime.min
 
 
 def _get_scan_cache(key):
@@ -377,8 +388,20 @@ class GraphClient:
 
         return items, total_rows
 
-    def _execute_paginated_search(self, kql, page, page_size, post_filters, reverse_map):
+    @staticmethod
+    def _parse_order_by(order_by):
+        if not order_by:
+            return None, False
+        parts = order_by.rsplit(" ", 1)
+        field = parts[0]
+        desc = len(parts) > 1 and parts[1] == "desc"
+        return field, desc
+
+    def _execute_paginated_search(self, kql, page, page_size, post_filters, reverse_map, order_by=None):  # noqa: PLR0913
+        sort_field, sort_desc = self._parse_order_by(order_by)
         if not post_filters:
+            # Graph API paginates by rank. Client-side sort per-page would
+            # make items jump between pages, so we skip it here.
             start_row = (page - 1) * page_size
             items, total_rows = self._execute_search_page(kql, start_row, page_size, reverse_map=reverse_map)
             logger.info(f"Graph Search API: {total_rows} total, returned {len(items)} for page {page}")
@@ -392,6 +415,7 @@ class GraphClient:
                     "kql": kql,
                     "post_filters": dict(sorted(post_filters.items())),
                     "page_size": page_size,
+                    "order_by": order_by,
                 },
                 sort_keys=True,
             ).encode(),
@@ -401,6 +425,8 @@ class GraphClient:
         all_items = _get_scan_cache(scan_key)
         if all_items is None:
             all_items = self._scan_all_post_filtered(kql, page_size, post_filters, reverse_map)
+            if sort_field:
+                all_items.sort(key=lambda i: _parse_last_modified(i, sort_field), reverse=sort_desc)
             _set_scan_cache(scan_key, all_items)
 
         total_rows = len(all_items)
@@ -437,6 +463,7 @@ class GraphClient:
         filters=None,
         page=1,
         searchable_properties=None,
+        order_by=None,
         **kwargs,
     ):
         """Search SharePoint content using the Microsoft Graph Search API.
@@ -455,6 +482,10 @@ class GraphClient:
                      searchable via KQL. Properties NOT in this set are
                      excluded from KQL and applied as post-filters after batch
                      enrichment. If None, all properties are treated as post-filters.
+            order_by: Sort expression (e.g. "LastModifiedTime desc").
+                      When set, results are sorted client-side by
+                      LastModifiedTime as a proper datetime comparison,
+                      not as a string.
             **kwargs: Extra keyword arguments for API compatibility.
                       Accepted kwargs:
                       - reverse_map: Dict mapping managed property names ->
@@ -476,7 +507,8 @@ class GraphClient:
                     post_filters[name] = value
 
         kql = RestBuilder.build_kql(search=search, filters=searchable_filters)
-        return self._execute_paginated_search(kql, page, page_size, post_filters, reverse_map)
+        logger.info("KQL query: %s | searchable: %s | post_filters: %s", kql, searchable_filters, post_filters)
+        return self._execute_paginated_search(kql, page, page_size, post_filters, reverse_map, order_by=order_by)
 
     def read_list_items(self, list_name):
         """Read all items from a SharePoint list via Graph API.

--- a/src/sharepoint_rest_api/graph_client.py
+++ b/src/sharepoint_rest_api/graph_client.py
@@ -345,7 +345,7 @@ class GraphClient:
             return site_id, list_id, list_item_id
         return None
 
-    def _execute_search_page(self, kql, start_row, page_size, reverse_map=None):
+    def _execute_search_page(self, kql, start_row, page_size, reverse_map=None, fields=None):
         """Execute a single search API page and return (items, total_rows) from raw results.
 
         Args:
@@ -353,9 +353,10 @@ class GraphClient:
             start_row: Zero-based row offset.
             page_size: Number of results to fetch.
             reverse_map: Optional dict of managed name -> serializer field name.
+            fields: Optional list of managed property names to include in results.
 
         """
-        body = RestBuilder.build_search_request_body(kql, start_row, page_size)
+        body = RestBuilder.build_search_request_body(kql, start_row, page_size, fields=fields)
         try:
             response = self.post(GRAPH_SEARCH_URL, json=body, timeout=60)
         except GraphClientError as e:
@@ -397,13 +398,15 @@ class GraphClient:
         desc = len(parts) > 1 and parts[1] == "desc"
         return field, desc
 
-    def _execute_paginated_search(self, kql, page, page_size, post_filters, reverse_map, order_by=None):  # noqa: PLR0913
+    def _execute_paginated_search(self, kql, page, page_size, post_filters, reverse_map, order_by=None, fields=None):  # noqa: PLR0913
         sort_field, sort_desc = self._parse_order_by(order_by)
         if not post_filters:
             # Graph API paginates by rank. Client-side sort per-page would
             # make items jump between pages, so we skip it here.
             start_row = (page - 1) * page_size
-            items, total_rows = self._execute_search_page(kql, start_row, page_size, reverse_map=reverse_map)
+            items, total_rows = self._execute_search_page(
+                kql, start_row, page_size, reverse_map=reverse_map, fields=fields
+            )
             logger.info(f"Graph Search API: {total_rows} total, returned {len(items)} for page {page}")
             return items, total_rows
 

--- a/tests/test_graph_client.py
+++ b/tests/test_graph_client.py
@@ -374,7 +374,7 @@ def test_kql_eq_filter_multi_value():
 
 def test_kql_not_filter():
     result = RestBuilder.build_kql(filters={"Donor__not": "Red Cross"})
-    assert result == 'Donor<>"Red Cross"'
+    assert result == '-Donor:"Red Cross"'
 
 
 def test_kql_contains_filter():
@@ -384,7 +384,7 @@ def test_kql_contains_filter():
 
 def test_kql_not_in_filter():
     result = RestBuilder.build_kql(filters={"Donor__not_in": "Red Cross,UNICEF"})
-    assert result == '-"Red Cross" AND -"UNICEF"'
+    assert result == '-"Red Cross" -"UNICEF"'
 
 
 def test_kql_unknown_operator():
@@ -399,14 +399,14 @@ def test_kql_exclusion_filter():
 
 def test_kql_search_with_filters():
     result = RestBuilder.build_kql(search="path:/docs", filters={"Donor": "Red Cross"})
-    assert result == 'path:/docs AND Donor:"Red Cross"'
+    assert result == 'path:/docs Donor:"Red Cross"'
 
 
 def test_kql_multiple_filters():
     result = RestBuilder.build_kql(filters={"Donor": "Red Cross", "ReportStatus": "Final"})
     assert 'Donor:"Red Cross"' in result
     assert 'ReportStatus:"Final"' in result
-    assert " AND " in result
+    assert " AND " not in result
 
 
 def test_kql_gte():

--- a/tests/test_rest_builder.py
+++ b/tests/test_rest_builder.py
@@ -29,7 +29,7 @@ def test_kql_clause_eq_multi():
 
 def test_kql_clause_not():
     result = RestBuilder.build_kql_clause("Donor__not", "Red Cross")
-    assert result == ['Donor<>"Red Cross"']
+    assert result == ['-Donor:"Red Cross"']
 
 
 def test_kql_clause_contains():
@@ -95,7 +95,7 @@ def test_kql_eq_filter_multi_value():
 
 def test_kql_not_filter():
     result = RestBuilder.build_kql(filters={"Donor__not": "Red Cross"})
-    assert result == 'Donor<>"Red Cross"'
+    assert result == '-Donor:"Red Cross"'
 
 
 def test_kql_contains_filter():
@@ -105,7 +105,7 @@ def test_kql_contains_filter():
 
 def test_kql_not_in_filter():
     result = RestBuilder.build_kql(filters={"Donor__not_in": "Red Cross,UNICEF"})
-    assert result == '-"Red Cross" AND -"UNICEF"'
+    assert result == '-"Red Cross" -"UNICEF"'
 
 
 def test_kql_unknown_operator():
@@ -115,14 +115,14 @@ def test_kql_unknown_operator():
 
 def test_kql_search_with_filters():
     result = RestBuilder.build_kql(search="path:/docs", filters={"Donor": "Red Cross"})
-    assert result == 'path:/docs AND Donor:"Red Cross"'
+    assert result == 'path:/docs Donor:"Red Cross"'
 
 
 def test_kql_multiple_filters():
     result = RestBuilder.build_kql(filters={"Donor": "Red Cross", "ReportStatus": "Final"})
     assert 'Donor:"Red Cross"' in result
     assert 'ReportStatus:"Final"' in result
-    assert " AND " in result
+    assert " AND " not in result
 
 
 def test_kql_gte():


### PR DESCRIPTION
- Replace explicit AND with space in build_kql (KQL treats space as AND)
- Fix <> operator to -property:value syntax for KQL negation
- Add _parse_last_modified and _parse_order_by helpers for client-side sort
- Remove debug print statements
- Add noqa for PLR0913 on _execute_paginated_search